### PR TITLE
filter out also falsy globals

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ export default function globalJsdom(html = defaultHtml, options = {}) {
   // that node already defines
 
   if (KEYS.length === 0) {
-    KEYS.push(...Object.getOwnPropertyNames(window).filter((k) => !k.startsWith('_')).filter((k) => !global[k]))
+    KEYS.push(...Object.getOwnPropertyNames(window).filter((k) => !k.startsWith('_')).filter((k) => !(k in global)))
     // going to add our jsdom instance, see below
     KEYS.push('$jsdom')
   }


### PR DESCRIPTION
If global is falsy (like NaN), it's not filtered out. Fixed here.