### PR TITLE
Fix jsdom peer dependency version specifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "jsdom": ">=10.0.0, <17"
+    "jsdom": ">=10.0.0 || <17"
   },
   "engines": {
     "node": ">=12"


### PR DESCRIPTION
A `,` is not a valid separator. You must use the `||` operator when specifying a range like this.

Tested via https://semver.npmjs.com/

<img width="1235" alt="Screen Shot 2021-04-20 at 8 35 10 AM" src="https://user-images.githubusercontent.com/2791730/115396781-5dcf0b80-a1b3-11eb-89dd-febfbcee0228.png">
<img width="1260" alt="Screen Shot 2021-04-20 at 8 35 17 AM" src="https://user-images.githubusercontent.com/2791730/115396785-5f98cf00-a1b3-11eb-8275-5abe55eab5b1.png">

