### PR TITLE
Export cleanup function from register entry-point

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ const cleanup = globalJsdom()
 cleanup()
 ```
 
+If using `global-jsdom/register` as the entry-point, `cleanup` is exported:
+
+```js
+// commonjs
+const cleanup = require('global-jsdom/register')
+
+// es2015
+import cleanup from 'global-jsdom/register'
+
+// do things, then
+cleanup()
+```
+
 ## Tape
 
 In [tape][], run it before your other tests.

--- a/commonjs/register.js
+++ b/commonjs/register.js
@@ -1,4 +1,4 @@
 /* eslint-disable */
 const jsdom = require('./index.js')
 
-jsdom()
+module.exports = jsdom()

--- a/esm/register.mjs
+++ b/esm/register.mjs
@@ -1,4 +1,4 @@
 /* eslint-disable */
 import jsdom from './index.mjs'
 
-jsdom()
+export default jsdom()


### PR DESCRIPTION
I thought that this could be useful in a few cases, but please ignore this if you feel it's not worth it.
Could help keep some code a little bit cleaner