### PR TITLE
fix(perf): condense filter function

### DIFF
--- a/commonjs/index.js
+++ b/commonjs/index.js
@@ -35,7 +35,7 @@ module.exports = function globalJsdom(html = defaultHtml, options = {}) {
   // that node already defines
 
   if (KEYS.length === 0) {
-    KEYS.push(...Object.getOwnPropertyNames(window).filter((k) => !k.startsWith('_')).filter((k) => !(k in global)))
+    KEYS.push(...Object.getOwnPropertyNames(window).filter((k) => !k.startsWith('_') && !(k in global)))
     // going to add our jsdom instance, see below
     KEYS.push('$jsdom')
   }

--- a/esm/index.mjs
+++ b/esm/index.mjs
@@ -35,7 +35,7 @@ export default function globalJsdom(html = defaultHtml, options = {}) {
   // that node already defines
 
   if (KEYS.length === 0) {
-    KEYS.push(...Object.getOwnPropertyNames(window).filter((k) => !k.startsWith('_')).filter((k) => !(k in global)))
+    KEYS.push(...Object.getOwnPropertyNames(window).filter((k) => !k.startsWith('_') && !(k in global)))
     // going to add our jsdom instance, see below
     KEYS.push('$jsdom')
   }


### PR DESCRIPTION
Pulling the logic of the two filter functions into a single `.filter` array prototype means the set of keys on `window` will only be traversed a single time.