### PR TITLE
feature: include typescript module declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,27 @@ import jQuery from 'jquery'
 // ...
 ```
 
+## Typescript
+
+The library includes automatic support providing the necessary type declarations for an integration without further configuration.
+
+```ts
+import globalJsdom from "global-jsdom";
+
+describe("Typescript test example", () => {
+	let cleanup: { (): void };
+
+	before(() => {
+		cleanup = globalJsdom();
+	});
+
+	after(() => {
+		cleanup();
+	});
+
+})
+```
+
 ## Migration from `jsdom-global`
 1. `browserify` support is dropped - I have no way to test this and `webpack` started giving higher priority to the `browser` field in `package.json` than `module`
 

--- a/packages/global-jsdom/package.json
+++ b/packages/global-jsdom/package.json
@@ -23,7 +23,8 @@
   "types": "types/index.d.ts",
   "files": [
     "commonjs/*",
-    "esm/*"
+    "esm/*",
+    "types/*"
   ],
   "bugs": {
     "url": "https://github.com/modosc/global-jsdom/issues"

--- a/packages/global-jsdom/package.json
+++ b/packages/global-jsdom/package.json
@@ -20,6 +20,7 @@
   },
   "module": "./esm/index.mjs",
   "main": "./commonjs/index.cjs",
+  "types": "types/index.d.ts",
   "files": [
     "commonjs/*",
     "esm/*"

--- a/packages/global-jsdom/types/index.d.ts
+++ b/packages/global-jsdom/types/index.d.ts
@@ -1,0 +1,7 @@
+declare module "global-jsdom" {
+	import { ConstructorOptions } from "jsdom";
+
+	function globalJsdom(html?: string, options?: ConstructorOptions): () => void;
+
+	export = globalJsdom;
+}


### PR DESCRIPTION
I'm working on a project where I've adopted Typescript as the "language".

I needed to include support for declaring types for a better development experience.

I believe it can be useful for other colleagues and that's why I make this suggestion.

If this is beneficial and brings real benefits, please approve the pull request.

I remain at your disposal if additional clarification is needed.

Thank you very much.