### PR TITLE
fix: TS error 7016

### DIFF
--- a/packages/global-jsdom/package.json
+++ b/packages/global-jsdom/package.json
@@ -11,7 +11,8 @@
   "exports": {
     ".": {
       "require": "./commonjs/index.cjs",
-      "default": "./esm/index.mjs"
+      "default": "./esm/index.mjs",
+      "types": "./types/index.d.ts"
     },
     "./register": {
       "require": "./commonjs/register.cjs",


### PR DESCRIPTION
Fix an error when importing global-jsdom from a module package.

Could not find a declaration file for module 'global-jsdom'. '/Users/.../node_modules/global-jsdom/esm/index.mjs' implicitly has an 'any' type.
  There are types at '/Users/.../node_modules/global-jsdom/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'global-jsdom' library may need to update its package.json or typings.