### PR TITLE
configure dependabot to only update jsdom

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
     interval: daily
     time: "13:00"
   open-pull-requests-limit: 10
+  allow:
+    - dependency-name: "jsdom"


### PR DESCRIPTION
`jsdom` updates get lost in the noise. this pr configures dependabot to _only_ update `jsdom`. 